### PR TITLE
Updates CONTRIBUTING, README, package author, and .lintr

### DIFF
--- a/.lintr
+++ b/.lintr
@@ -1,0 +1,4 @@
+linters: with_defaults(
+    line_length_linter = line_length_linter(120),
+    object_usage_linter = NULL
+  )

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,13 +14,15 @@ We welcome contributions to `Rgemini` by all GEMINI team members. To submit a co
 
 6. If appropriate, add unit tests in the `tests/testthat/` directory.
 
-7. If adding new functions with new documentation, run `devtools::document()` and update the `_pkgdown.yml` file by adding the new function to the appropriate reference section.
+7. If adding new functions with new documentation, update the `_pkgdown.yml` file by adding the new function to the appropriate reference section. Note that the `Rgemini` repository currently has a CI/CD workflow to generate and commit documentation on any pushed commit, but `devtools::document()` can also be run during development to debug locally. 
 
-8. Submit a [pull request](https://help.github.com/articles/using-pull-requests) into the `develop` branch.
+8. Note that any new package data should be saved as a `.rda` file in the `data/` directory, and should be documented with `roxygen` in `data.R`.
 
-9. Ask a team member to review the changes (see guidelines for reviewers below) and implement additional changes based on the reviewer's feedback.
+9. Submit a [pull request](https://help.github.com/articles/using-pull-requests) into the `develop` branch.
 
-10. Once the reviewer has approved the pull request, squash all commits and merge the branch into `develop`, close the issue, and delete the branch you developed on.
+10. Ask a team member to review the changes (see guidelines for reviewers below) and implement additional changes based on the reviewer's feedback.
+
+11. Once the reviewer has approved the pull request, squash all commits and merge the branch into `develop`, close the issue, and delete the branch you developed on.
 
 
 # Reviewing code

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,11 +14,13 @@ We welcome contributions to `Rgemini` by all GEMINI team members. To submit a co
 
 6. If appropriate, add unit tests in the `tests/testthat/` directory.
 
-7. Submit a [pull request](https://help.github.com/articles/using-pull-requests) into the `develop` branch.
+7. If adding new functions with new documentation, run `devtools::document()` and update the `_pkgdown.yml` file by adding the new function to the appropriate reference section.
 
-8. Ask a team member to review the changes (see guidelines for reviewers below) and implement additional changes based on the reviewer's feedback.
+8. Submit a [pull request](https://help.github.com/articles/using-pull-requests) into the `develop` branch.
 
-9. Once the reviewer has approved the pull request, squash all commits and merge the branch into `develop`, close the issue, and delete the branch you developed on.
+9. Ask a team member to review the changes (see guidelines for reviewers below) and implement additional changes based on the reviewer's feedback.
+
+10. Once the reviewer has approved the pull request, squash all commits and merge the branch into `develop`, close the issue, and delete the branch you developed on.
 
 
 # Reviewing code

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: Rgemini
 Type: Package
 Title: R Functions for GEMINI Data
 Version: 0.3.1
-Author: The GEMINI team
+Author: GEMINI
 Maintainer: GEMINIdata <Gemini.data@unityhealth.to>
 Description: Common functions for GEMINI data analyses.
 License: MIT + file LICENSE

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ If the installation method above does not work, try one of the following:
 1. Install using `pak::pkg_install("GEMINI-Medicine/Rgemini")`.
 2. `git clone` the package to some directory such as `/path/to/repo`, and run `devtools::install("/path/to/repo", build_vignettes = TRUE)`.
 3. Download the latest source tarball from the [package releases](https://github.com/GEMINI-Medicine/Rgemini/tags) to some directory such as `/path/to/tarball` and run `install.packages("/path/to/tarball", repos = NULL, type="source")`.
+4. Try configuring secure downloads as described in [this blog post](https://support.posit.co/hc/en-us/articles/206827897-Secure-Package-Downloads-for-R).
 
 If none of the above methods work, please create a post on our [discussion board](https://github.com/GEMINI-Medicine/Rgemini/discussions/categories/q-a).
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ If the installation method above does not work, try one of the following:
 1. Install using `pak::pkg_install("GEMINI-Medicine/Rgemini")`.
 2. `git clone` the package to some directory such as `/path/to/repo`, and run `devtools::install("/path/to/repo", build_vignettes = TRUE)`.
 3. Download the latest source tarball from the [package releases](https://github.com/GEMINI-Medicine/Rgemini/tags) to some directory such as `/path/to/tarball` and run `install.packages("/path/to/tarball", repos = NULL, type="source")`.
-4. Try configuring secure downloads as described in [this blog post](https://support.posit.co/hc/en-us/articles/206827897-Secure-Package-Downloads-for-R).
+4. Try configuring secure downloads as described in [this blog post](https://support.posit.co/hc/en-us/articles/206827897-Secure-Package-Downloads-for-R37).
 
 If none of the above methods work, please create a post on our [discussion board](https://github.com/GEMINI-Medicine/Rgemini/discussions/categories/q-a).
 
@@ -106,3 +106,5 @@ Usually we accumulate a series of changes on develop and release them all at onc
 If you find `Rgemini` useful, please cite it in your publications using `citation("Rgemini")`:
 
 > The GEMINI team (2023). Rgemini: R Functions for GEMINI Data. R package version 0.3.0. https://gemini-medicine.github.io/Rgemini/
+
+Note that particular functions may require additional citations. Please consult the references in function-specific documentation whenever applicable.


### PR DESCRIPTION
This PR covers 3 simple package configuration/documentation issues:

Closes #37: Adding `pkgdown` instructions to `CONTRIBUTING.md`.
Closes #11: Adding a `.lintr` file.
Closes #22: Adding secure download (encrypted HTTPS) instructions to `README.md`.
Closes #5: Edits package author name to improve citation.

@gemini-wenb could you take a look at the installation instructions (#22) and let me know if anything should be made more clear or explicit?