### PR TITLE
Fix bug in factor level #23

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,7 @@
 
 * Allows the user to specify the number of digits to round percentages to in cell suppression of categorical variables, without forcing rounding to integer.
 * Allows user to render only one level for binary variables in `table1`.
+* Fixes singularity due to missing levels in `table1`.
 * Fixes `find_db_tablename` and `readmission` for DBs with foreign data wrappers.
 
 # Rgemini 0.3.0

--- a/R/cell_suppression.R
+++ b/R/cell_suppression.R
@@ -56,7 +56,8 @@ max_pairwise_smd <- function(x, name, round_to = 3, ...) {
   for (pair in pairs) {
 
     current_smd <- max(
-      fn(x %>% dplyr::filter(L1 %in% pair), 2, 1) %>% .[[1, "stddiff"]] # alternate reference group through every group
+      fn(x %>% dplyr::filter(L1 %in% pair) %>% droplevels(), # drop factor levels, otherwise singularity may arise for group(s) containing an empty level 
+         2, 1) %>% .[[1, "stddiff"]] # alternate reference group through every group 
     )
 
     if (is.na(current_smd)) {

--- a/tests/testthat/test-create_table1_gemini.R
+++ b/tests/testthat/test-create_table1_gemini.R
@@ -74,3 +74,15 @@ test_that("categorial cell suppression doesn't round to the nearest integer", {
     c("", "a" = "1000 (49.8%)", "b" = "1010 (50.2%)")
   )
 })
+
+test_that("when a factor variable is missing levels, still can calculate SMD", {
+  g <- rep(LETTERS[1:3], each = 30)
+  x <- c(rep('d', 20), rep('e', 10), rep('d', 16), rep('e', 12), rep('f', 1), rep('g', 1), rep('d', 10), rep('e', 19), rep('g',1))
+
+  df <- data.frame(hosp = g, gender = x)
+
+  expect_equal(
+    max_pairwise_smd(split(df$gender, df$hosp)),
+    0.734
+  )
+})


### PR DESCRIPTION
closes #23 

This bug is due to singularity arises from `stddiff::stddiff.category()` (a function called by `Rgemini::max_pairwise_smd_fix()`). 
When looping through each pair, `stddiff::stddiff.category()` calculates SMD. However, if a particular pair doesn't have values for all levels of the factor, the empty level will result in a singular matrix. 

To fix this, `droplevels()` is applied to the paired data.

e.g. For pair A-C, the factor variable "category" contains an empty level "o", resulting in singularity. For other pairs, such as A-B, "category" has value at all levels and thus will run as expected. 
![image](https://github.com/GEMINI-Medicine/Rgemini/assets/133171927/d82325be-9b99-46cd-8685-718c3d00cbe4)

Below code demonstrates the error and the fix:

```
max_pairwise_smd_fix <- function(x, name, round_to = 3, ...) {
  x[["overall"]] <- NULL # remove overall category if exists
  x <- reshape2::melt(x)
  x$L1 <- as.numeric(as.factor(x$L1)) - 1 # needs to start at 0 for stddiff
  pairs <- unique(x$L1) %>% combn(2, simplify = FALSE)
  vartype <- class(x$value)
  fn <- if ((vartype == "numeric") || is.integer(x$value)) {
    stddiff::stddiff.numeric
  } else if (vartype == "logical") {
    stddiff::stddiff.binary
  } else if (vartype %in% c("factor", "character")) {
    stddiff::stddiff.category
  }
  max_smd <- 0
  for (pair in pairs) {
    current_smd <- max(
      fn(x %>% dplyr::filter(L1 %in% pair) %>% droplevels() , # drop factor levels, otherwise singularity may arise for group(s) containing an empty level
         2, 1) %>%  .[[1, "stddiff"]] # alternate reference group through every group 
    )
    if (is.na(current_smd)) {
      warning("Some pairwise SMDs could not be calculated. Please investigate.", .call = FALSE)
      max_smd <- current_smd
      
    } else if ((current_smd > max_smd) || is.na(max_smd)) {
      max_smd <- current_smd
    }
  }
  return(round(max_smd, round_to))
}

######################### Fake data (same data as #23 )
g <- rep(LETTERS[1:3], each = 30)
x <- c(rep('f', 20), rep('m', 10), 
       rep('f', 16), rep('m', 12), rep('o', 1), rep('x', 1),
       rep('f', 10), rep('m', 19), rep('x', 1) )
df <- data.table(cat = x, hos = g)

strata <- c(list(Total=df), split(df, df$hos))

labels <- list(
  variables=list(cat='category')
)

############################# Returns error due to singularity
table1(strata, labels, groupspan=c(1, 1, 2), extra.col = list("SMD" = Rgemini::max_pairwise_smd))
````
![image](https://github.com/GEMINI-Medicine/Rgemini/assets/133171927/63aad5a6-20a3-4966-847e-2020f0c66086)

```
#############################  Returns table1 as expected with the fix
table1(strata, labels, groupspan=c(1, 1, 2), extra.col = list("SMD" = max_pairwise_smd_fix))
```
![image](https://github.com/GEMINI-Medicine/Rgemini/assets/133171927/fb03375b-8196-4f57-9839-a0a6219fc25c)

