### PR TITLE
38 dbcon examples

### DIFF
--- a/R/covid_flag.R
+++ b/R/covid_flag.R
@@ -85,7 +85,7 @@
 #' drv <- dbDriver("PostgreSQL")
 #' dbcon <- DBI::dbConnect(drv,
 #'                         dbname = "db",
-#'                         host = "172.XX.XX.XXX",
+#'                         host = "domain_name.ca",
 #'                         port = 1234,
 #'                         user = getPass("Enter user:"),
 #'                         password = getPass("password"))

--- a/R/daily_census.R
+++ b/R/daily_census.R
@@ -117,7 +117,7 @@
 #' drv <- dbDriver("PostgreSQL")
 #' dbcon <- DBI::dbConnect(drv,
 #'                         dbname = "db",
-#'                         host = "172.XX.XX.XXX",
+#'                         host = "domain_name.ca",
 #'                         port = 1234,
 #'                         user = getPass("Enter user:"),
 #'                         password = getPass("password"))

--- a/R/dummy_data.R
+++ b/R/dummy_data.R
@@ -38,7 +38,7 @@
 #' drv <- dbDriver("PostgreSQL")
 #' dbcon <- DBI::dbConnect(drv,
 #'   dbname = "db",
-#'   host = "172.XX.XX.XXX",
+#'   host = "domain_name.ca",
 #'   port = 1234,
 #'   user = getPass("Enter user:"),
 #'   password = getPass("password")

--- a/R/episodes_of_care.R
+++ b/R/episodes_of_care.R
@@ -83,7 +83,7 @@
 #' drv <- dbDriver("PostgreSQL")
 #' dbcon <- DBI::dbConnect(drv,
 #'                         dbname = "db",
-#'                         host = "172.XX.XX.XXX",
+#'                         host = "domain_name.ca",
 #'                         port = 1234,
 #'                         user = getPass("Enter user:"),
 #'                         password = getPass("password"))

--- a/R/icd_to_ccsr.R
+++ b/R/icd_to_ccsr.R
@@ -118,7 +118,7 @@
 #' drv <- dbDriver("PostgreSQL")
 #' dbcon <- DBI::dbConnect(drv,
 #'                         dbname = "db",
-#'                         host = "172.XX.XX.XXX",
+#'                         host = "domain_name.ca",
 #'                         port = 1234,
 #'                         user = getPass("Enter user:"),
 #'                         password = getPass("password"))

--- a/R/mlaps.R
+++ b/R/mlaps.R
@@ -110,7 +110,7 @@ laps_assign_test <- function(x, breaks, points) {
 #' db <- DBI::dbConnect(
 #'   drv,
 #'   dbname = "db_name",
-#'   host = "172.XX.XX.XXX",
+#'   host = "domain_name.ca",
 #'   port = 1234,
 #'   user = getPass::getPass("Enter Username"),
 #'   password = getPass::getPass("Enter Password")

--- a/R/readmission.R
+++ b/R/readmission.R
@@ -113,7 +113,7 @@
 #' drv <- dbDriver("PostgreSQL")
 #' dbcon <- DBI::dbConnect(drv,
 #'                         dbname = "db",
-#'                         host = "172.XX.XX.XXX",
+#'                         host = "domain_name.ca",
 #'                         port = 1234,
 #'                         user = getPass("Enter user:"),
 #'                         password = getPass("password"))

--- a/R/stat_holidays_ON.R
+++ b/R/stat_holidays_ON.R
@@ -35,7 +35,7 @@
 #' drv <- dbDriver("PostgreSQL")
 #' dbcon <- DBI::dbConnect(drv,
 #'                         dbname = "db",
-#'                         host = "172.XX.XX.XXX",
+#'                         host = "domain_name.ca",
 #'                         port = 1234,
 #'                         user = getPass("Enter user:"),
 #'                         password = getPass("password"))

--- a/R/utils.R
+++ b/R/utils.R
@@ -227,7 +227,7 @@ coerce_to_datatable <- function(data) {
 #' drv <- dbDriver("PostgreSQL")
 #' dbcon <- DBI::dbConnect(drv,
 #'   dbname = "db",
-#'   host = "172.XX.XX.XXX",
+#'   host = "domain_name.ca",
 #'   port = 1234,
 #'   user = getPass("Enter user:"),
 #'   password = getPass("password")
@@ -550,7 +550,7 @@ check_input <- function(arginput, argtype,
             "We recommend the following method to establish a DB connection:\n",
             "drv <- dbDriver('PostgreSQL')\n",
             "dbcon <- DBI::dbConnect(drv, dbname = 'db_name', ",
-            "host = 'domain_name.net', port = 1234, ",
+            "host = 'domain_name.ca', port = 1234, ",
             "user = getPass('Enter user:'), password = getPass('password'))\n",
             "\nPlease refer to the function documentation for more details."
           ),

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ drv <- DBI::dbDriver("PostgreSQL")
 db <- DBI::dbConnect(
   drv,
   dbname = "db_name",
-  host = "172.XX.XX.XXX",
+  host = "domain_name.ca",
   port = 1234,
   user = getPass::getPass("Enter Username"),
   password = getPass::getPass("Enter Password")

--- a/man/covid_flag.Rd
+++ b/man/covid_flag.Rd
@@ -92,7 +92,7 @@ make sure list of admissions (or patient) aligns in both tables.
 drv <- dbDriver("PostgreSQL")
 dbcon <- DBI::dbConnect(drv,
                         dbname = "db",
-                        host = "172.XX.XX.XXX",
+                        host = "domain_name.ca",
                         port = 1234,
                         user = getPass("Enter user:"),
                         password = getPass("password"))

--- a/man/daily_census.Rd
+++ b/man/daily_census.Rd
@@ -128,7 +128,7 @@ a standardized measure of patient counts, rather than a measure of true capacity
 drv <- dbDriver("PostgreSQL")
 dbcon <- DBI::dbConnect(drv,
                         dbname = "db",
-                        host = "172.XX.XX.XXX",
+                        host = "domain_name.ca",
                         port = 1234,
                         user = getPass("Enter user:"),
                         password = getPass("password"))

--- a/man/episodes_of_care.Rd
+++ b/man/episodes_of_care.Rd
@@ -80,7 +80,7 @@ concepts is needed for proper use of the function: transfer coded vs. transfer o
 drv <- dbDriver("PostgreSQL")
 dbcon <- DBI::dbConnect(drv,
                         dbname = "db",
-                        host = "172.XX.XX.XXX",
+                        host = "domain_name.ca",
                         port = 1234,
                         user = getPass("Enter user:"),
                         password = getPass("password"))

--- a/man/find_db_tablename.Rd
+++ b/man/find_db_tablename.Rd
@@ -58,7 +58,7 @@ suffix (for HPC datacuts).
 drv <- dbDriver("PostgreSQL")
 dbcon <- DBI::dbConnect(drv,
   dbname = "db",
-  host = "172.XX.XX.XXX",
+  host = "domain_name.ca",
   port = 1234,
   user = getPass("Enter user:"),
   password = getPass("password")

--- a/man/icd_to_ccsr.Rd
+++ b/man/icd_to_ccsr.Rd
@@ -125,7 +125,7 @@ carefully read the documentation to understand how exactly invalid PDX categorie
 drv <- dbDriver("PostgreSQL")
 dbcon <- DBI::dbConnect(drv,
                         dbname = "db",
-                        host = "172.XX.XX.XXX",
+                        host = "domain_name.ca",
                         port = 1234,
                         user = getPass("Enter user:"),
                         password = getPass("password"))

--- a/man/readmission.Rd
+++ b/man/readmission.Rd
@@ -136,7 +136,7 @@ Warnings are produced if
 drv <- dbDriver("PostgreSQL")
 dbcon <- DBI::dbConnect(drv,
                         dbname = "db",
-                        host = "172.XX.XX.XXX",
+                        host = "domain_name.ca",
                         port = 1234,
                         user = getPass("Enter user:"),
                         password = getPass("password"))

--- a/man/sample_icd.Rd
+++ b/man/sample_icd.Rd
@@ -44,7 +44,7 @@ sample_icd(100, source = "comorbidity", pattern = "^C2|^E10")
 drv <- dbDriver("PostgreSQL")
 dbcon <- DBI::dbConnect(drv,
   dbname = "db",
-  host = "172.XX.XX.XXX",
+  host = "domain_name.ca",
   port = 1234,
   user = getPass("Enter user:"),
   password = getPass("password")

--- a/man/stat_holidays_ON.Rd
+++ b/man/stat_holidays_ON.Rd
@@ -42,7 +42,7 @@ with a holiday table to flag which dates are holidays/observed holidays.
 drv <- dbDriver("PostgreSQL")
 dbcon <- DBI::dbConnect(drv,
                         dbname = "db",
-                        host = "172.XX.XX.XXX",
+                        host = "domain_name.ca",
                         port = 1234,
                         user = getPass("Enter user:"),
                         password = getPass("password"))


### PR DESCRIPTION
Closes issue #38 

Changed all examples of how to connect to the DB to `host = “domain_name.ca”` instead of fake IP address. Also updated instructions in `README` and warning message in `check_input`. 