### PR TITLE
67 bigmark table1

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 # Rgemini `develop`
 
 * Updated unit tests & small bug fix in `daily_census` 
+* Enable `prettyNum` formatting in table 1 render functions
 
 # Rgemini 0.4.2
 

--- a/R/cell_suppression.R
+++ b/R/cell_suppression.R
@@ -135,7 +135,7 @@ render_cell_suppression.default <- function(
   if (is.logical(x)) x <- factor(x, levels = c(T, F), labels = c("Yes", "No"))
 
   if (is.factor(x) || is.character(x)) {
-    r <- do.call(render.categorical, c(list(x = x), list(...)))
+    r <- do.call(render.categorical, list(x = x, ...))
 
   } else if (is.numeric(x)) {
 
@@ -145,7 +145,7 @@ render_cell_suppression.default <- function(
       render.continuous <- render_mean.continuous
     }
 
-    r <- do.call(render.continuous, c(list(x = x), list(...)))
+    r <- do.call(render.continuous, list(x = x, ...))
 
   } else {
 
@@ -153,7 +153,7 @@ render_cell_suppression.default <- function(
   }
 
   if (missing && !is.null(render.missing)) {
-    r <- c(r, do.call(render.missing, c(list(x = x), list(...))))
+    r <- c(r, do.call(render.missing, list(x = x, ...)))
   }
   
   if (transpose) {

--- a/R/cell_suppression.R
+++ b/R/cell_suppression.R
@@ -107,7 +107,8 @@ max_pairwise_smd <- function(x, name, round_to = 3, ...) {
 #' in which case it is passed to `table1:::parse.abbrev.render.code()`. Set to `NULL` to ignore missing values.
 #'
 #' @param ... \cr
-#' Further arguments, passed to `table1:::stats.apply.rounding()`.
+#' Further arguments, passed to `table1:::stats.apply.rounding()` or
+#' `prettyNum()` for additional formatting (e.g., `big.mark = ","`).
 #'
 #' @return (`character`)\cr
 #' Summary of variable as a character vector with cell suppression applied.
@@ -134,7 +135,7 @@ render_cell_suppression.default <- function(
   if (is.logical(x)) x <- factor(x, levels = c(T, F), labels = c("Yes", "No"))
 
   if (is.factor(x) || is.character(x)) {
-    r <- do.call(render.categorical, list(x = x))
+    r <- do.call(render.categorical, c(list(x = x), list(...)))
 
   } else if (is.numeric(x)) {
 
@@ -152,9 +153,9 @@ render_cell_suppression.default <- function(
   }
 
   if (missing && !is.null(render.missing)) {
-    r <- c(r, do.call(render.missing, list(x = x)))
+    r <- c(r, do.call(render.missing, c(list(x = x), list(...))))
   }
-
+  
   if (transpose) {
     if (!is.null(names(r))) {
       r <- paste0(sprintf("%s: %s", names(r), r), collapse = "<br/>")
@@ -183,7 +184,9 @@ render_cell_suppression.default <- function(
 #'
 #' @param ... \cr
 #' Optionally accept a named `digits` (`integer`) or `single_level_binary` (`logical`) argument
-#' which specifiesthe number of digits to round percentages to.
+#' which specifies the number of digits to round percentages to.
+#' Also accepts additional inputs that are passed to `prettyNum()` to apply
+#' additional formatting to shown results (e.g., `big.mark = ","`).
 #'
 #' @return named (`character`)\cr
 #' Concatenated with `""` to shift values down one row for proper alignment.
@@ -261,7 +264,7 @@ render_cell_suppression.categorical <- function(x, ...) {
       transmute(summary = sprintf(output_format, frequency, pct))
   }
 
-  res <- t(contents) %>% as.character()
+  res <- prettyNum(t(contents), ...) %>% as.character()
   names(res) <- colnames(t(contents))
 
   if (
@@ -288,7 +291,9 @@ render_cell_suppression.categorical <- function(x, ...) {
 #'
 #' @param ... \cr
 #' Optionally accept a named `digits` (`integer`) or `single_level_binary` (`logical`) argument
-#' which specifiesthe number of digits to round percentages to.
+#' which specifies the number of digits to round percentages to.
+#' Also accepts additional inputs that are passed to `prettyNum()` to apply
+#' additional formatting to shown results (e.g., `big.mark = ","`).
 #'
 #' @return named (`character`)\cr
 #' Concatenated with `""` to shift values down one row for proper alignment.
@@ -345,7 +350,7 @@ render_strict_cell_suppression.categorical <- function(x, ...) {
       )
     )
 
-  res <- t(contents) %>% as.character()
+  res <- prettyNum(t(contents), ...) %>% as.character()
   names(res) <- colnames(t(contents))
 
   if (
@@ -495,12 +500,13 @@ render_cell_suppression.continuous <- function(x, ...) {
 #' @export
 #'
 render_cell_suppression.strat <- function(label, n, transpose = FALSE) {
+  
   sprintf(
     ifelse(
       is.na(n),
       "<span class='stratlabel'>%s</span>",
       ifelse(
-        as.numeric(n) < 6,
+        as.numeric(gsub("[^0-9.-]", "", n)) < 6, # need to remove any optional formatting here to check numeric value
         "<span class='stratlabel'>%s<br><span class='stratn'>(N&lt; 6 obs. (suppressed))</span></span>",
         "<span class='stratlabel'>%s<br><span class='stratn'>(N=%s)</span></span>"
       )
@@ -519,6 +525,10 @@ render_cell_suppression.strat <- function(label, n, transpose = FALSE) {
 #' @param x (`character` or `factor`)\cr
 #' A discrete variable to summarize.
 #'
+#' @param ... \cr
+#' Further arguments, passed to `prettyNum()` for additional formatting (e.g.,
+#' `big.mark = ","`).
+#'
 #' @return named (`character`)\cr
 #' Concatenated with `""` to shift values down one row for proper alignment.
 #'
@@ -528,10 +538,10 @@ render_cell_suppression.strat <- function(label, n, transpose = FALSE) {
 #' @examples
 #' render_default.discrete(mtcars$vs)
 #'
-render_default.discrete <- function(x) {
+render_default.discrete <- function(x, ...) {
   with(
     stats.default(x),
-    c("", Sum = sprintf("%s", SUM))
+    c("", Sum = prettyNum(sprintf("%s", SUM), ...))
   )
 }
 
@@ -585,7 +595,11 @@ render_cell_suppression.discrete <- function(x) {
 #'
 #' @param x (`character` or `factor`)\cr
 #' A variable with missing values to summarize.
-#'
+#' 
+#' @param ... \cr
+#' Further arguments, passed to `prettyNum()` for additional formatting (e.g.,
+#' `big.mark = ","`).
+#' 
 #' @return named (`character`)\cr
 #' Concatenated with `""` to shift values down one row for proper alignment.
 #'
@@ -600,10 +614,10 @@ render_cell_suppression.discrete <- function(x) {
 #' x[5:10] <- NA
 #' render_cell_suppression.missing(x)
 #'
-render_cell_suppression.missing <- function(x) {
+render_cell_suppression.missing <- function(x, ...) {
   if (sum(is.na(x)) < 6) {
     c("", Missing = "&lt; 6 obs. (suppressed)")
   } else {
-    render.missing.default(x)
+    prettyNum(render.missing.default(x), ...)
   }
 }

--- a/R/cell_suppression.R
+++ b/R/cell_suppression.R
@@ -597,8 +597,8 @@ render_cell_suppression.discrete <- function(x) {
 #' A variable with missing values to summarize.
 #' 
 #' @param ... \cr
-#' Further arguments, passed to `prettyNum()` for additional formatting (e.g.,
-#' `big.mark = ","`).
+#' Further arguments, passed to `table1:::stats.apply.rounding()` and
+#' `prettyNum()` for additional formatting (e.g., `big.mark = ","`).
 #' 
 #' @return named (`character`)\cr
 #' Concatenated with `""` to shift values down one row for proper alignment.
@@ -615,9 +615,14 @@ render_cell_suppression.discrete <- function(x) {
 #' render_cell_suppression.missing(x)
 #'
 render_cell_suppression.missing <- function(x, ...) {
+  args <- list(...)
   if (sum(is.na(x)) < 6) {
     c("", Missing = "&lt; 6 obs. (suppressed)")
   } else {
-    prettyNum(render.missing.default(x), ...)
+    if (!is.null(args$digits)) {
+      prettyNum(render.missing.default(x, digits.pct = args$digits), ...)
+    } else {
+      prettyNum(render.missing.default(x), ...)
+    }
   }
 }

--- a/man/mlaps.Rd
+++ b/man/mlaps.Rd
@@ -40,7 +40,7 @@ If \code{componentwise == FALSE}:
 mLAPS
 }
 \details{
-Modified Laboratory based Acute Physiology Score (mLAPS) uses 13 lab test values.
+Modified Laboratory based Acute Physiology Score (mLAPS) uses 14 lab test values.
 In this modified version, High senstive Troponin tests are ignored and treated as normal.
 }
 \note{

--- a/man/render_cell_suppression.categorical.Rd
+++ b/man/render_cell_suppression.categorical.Rd
@@ -12,7 +12,9 @@ A categorical variable to summarize.}
 
 \item{...}{\cr
 Optionally accept a named \code{digits} (\code{integer}) or \code{single_level_binary} (\code{logical}) argument
-which specifiesthe number of digits to round percentages to.}
+which specifies the number of digits to round percentages to.
+Also accepts additional inputs that are passed to \code{prettyNum()} to apply
+additional formatting to shown results (e.g., \code{big.mark = ","}).}
 }
 \value{
 named (\code{character})\cr

--- a/man/render_cell_suppression.default.Rd
+++ b/man/render_cell_suppression.default.Rd
@@ -45,7 +45,8 @@ A function to render missing (i.e. NA) values. Can also be a character string,
 in which case it is passed to \code{table1:::parse.abbrev.render.code()}. Set to \code{NULL} to ignore missing values.}
 
 \item{...}{\cr
-Further arguments, passed to \code{table1:::stats.apply.rounding()}.}
+Further arguments, passed to \code{table1:::stats.apply.rounding()} or
+\code{prettyNum()} for additional formatting (e.g., \code{big.mark = ","}).}
 }
 \value{
 (\code{character})\cr

--- a/man/render_cell_suppression.missing.Rd
+++ b/man/render_cell_suppression.missing.Rd
@@ -4,11 +4,15 @@
 \alias{render_cell_suppression.missing}
 \title{Render Cell Suppression (Missing)}
 \usage{
-render_cell_suppression.missing(x)
+render_cell_suppression.missing(x, ...)
 }
 \arguments{
 \item{x}{(\code{character} or \code{factor})\cr
 A variable with missing values to summarize.}
+
+\item{...}{\cr
+Further arguments, passed to \code{prettyNum()} for additional formatting (e.g.,
+\code{big.mark = ","}).}
 }
 \value{
 named (\code{character})\cr

--- a/man/render_cell_suppression.missing.Rd
+++ b/man/render_cell_suppression.missing.Rd
@@ -11,8 +11,8 @@ render_cell_suppression.missing(x, ...)
 A variable with missing values to summarize.}
 
 \item{...}{\cr
-Further arguments, passed to \code{prettyNum()} for additional formatting (e.g.,
-\code{big.mark = ","}).}
+Further arguments, passed to \code{table1:::stats.apply.rounding()} and
+\code{prettyNum()} for additional formatting (e.g., \code{big.mark = ","}).}
 }
 \value{
 named (\code{character})\cr

--- a/man/render_default.discrete.Rd
+++ b/man/render_default.discrete.Rd
@@ -4,11 +4,15 @@
 \alias{render_default.discrete}
 \title{Render Default (Discrete)}
 \usage{
-render_default.discrete(x)
+render_default.discrete(x, ...)
 }
 \arguments{
 \item{x}{(\code{character} or \code{factor})\cr
 A discrete variable to summarize.}
+
+\item{...}{\cr
+Further arguments, passed to \code{prettyNum()} for additional formatting (e.g.,
+\code{big.mark = ","}).}
 }
 \value{
 named (\code{character})\cr

--- a/man/render_strict_cell_suppression.categorical.Rd
+++ b/man/render_strict_cell_suppression.categorical.Rd
@@ -12,7 +12,9 @@ A categorical variable to summarize.}
 
 \item{...}{\cr
 Optionally accept a named \code{digits} (\code{integer}) or \code{single_level_binary} (\code{logical}) argument
-which specifiesthe number of digits to round percentages to.}
+which specifies the number of digits to round percentages to.
+Also accepts additional inputs that are passed to \code{prettyNum()} to apply
+additional formatting to shown results (e.g., \code{big.mark = ","}).}
 }
 \value{
 named (\code{character})\cr


### PR DESCRIPTION
Closes #67 

I’ve implemented some enhancement for each render function to allow for additional user inputs that are passed to `prettyNum`, which enables additional formatting that can be useful when presenting large numbers (e.g., big.mark = “,” to add comma thousands separator). I’ve tested all render functions to check if the updated code produces the expected output (see screenshot below) and made sure that nothing breaks. 

I also added a small bug fix for `digits` to be applied consistently to all outputs, including % missing.

The person reviewing the changes should perform some additional testing. The following code can be used as a starting point (you can comment/uncomment the different render functions to test each function's behavior): 

```
set.seed(3)
gender <- c(sample(c("M", "F"), size = 99995, replace = TRUE), rep(NA, times = 5))
exposure <- sample(
  c("pre-pandemic", "pandemic", "post-pandemic"), 
  size = 100000, replace = TRUE
)
income <- c(rnorm(90000, mean = 70000, sd = 5000), rep(NA, times = 10000))
condition <- sample(
  c("DVT", "CVD", "DM", "Pneumonia", "Dementia", NA), 
  size = 100000, replace = TRUE, prob = c(0.01, 0.20, 0.4, 0.35, 0.05, .01)
)
data <- data.frame(gender = gender, exposure = exposure, income = income, condition = condition)

table1(
  ~ gender + income + condition | exposure, 
  data = data, 
  render = render_cell_suppression.default, 
  digits = 2,
  big.mark = ",",
  #render.categorical = render_cell_suppression.categorical, # or: render_strict_cell_suppression.categorical,
  #render.continuous = render_cell_suppression.continuous
  #render.missing = render_cell_suppression.missing
  render.strat = render_cell_suppression.strat
)
```
![Screenshot 2024-05-14 153132](https://github.com/GEMINI-Medicine/Rgemini/assets/104941195/092f8462-d7d7-4aac-b979-9a0a8e965280)


