### PR TITLE
85 fix error when input has labelled class

### DIFF
--- a/R/cell_suppression.R
+++ b/R/cell_suppression.R
@@ -42,6 +42,7 @@ max_pairwise_smd <- function(x, name, round_to = 3, ...) {
   pairs <- unique(x$L1) %>% combn(2, simplify = FALSE)
 
   vartype <- class(x$value)
+  vartype <- vartype[!vartype=="labelled"]
 
   fn <- if ((vartype == "numeric") || is.integer(x$value)) {
     stddiff.numeric
@@ -56,8 +57,8 @@ max_pairwise_smd <- function(x, name, round_to = 3, ...) {
   for (pair in pairs) {
 
     current_smd <- max(
-      fn(x %>% dplyr::filter(L1 %in% pair) %>% droplevels(), # drop factor levels, otherwise singularity may arise for group(s) containing an empty level 
-         2, 1) %>% .[[1, "stddiff"]] # alternate reference group through every group 
+      fn(x %>% dplyr::filter(L1 %in% pair) %>% droplevels(), # drop factor levels, otherwise singularity may arise for group(s) containing an empty level
+         2, 1) %>% .[[1, "stddiff"]] # alternate reference group through every group
     )
 
     if (is.na(current_smd)) {

--- a/man/mlaps.Rd
+++ b/man/mlaps.Rd
@@ -40,7 +40,7 @@ If \code{componentwise == FALSE}:
 mLAPS
 }
 \details{
-Modified Laboratory based Acute Physiology Score (mLAPS) uses 13 lab test values.
+Modified Laboratory based Acute Physiology Score (mLAPS) uses 14 lab test values.
 In this modified version, High senstive Troponin tests are ignored and treated as normal.
 }
 \note{


### PR DESCRIPTION
This PR closes #85 

After further investigation, the error was due to `label()` in `table1()` masked by `Hmisc::label()`, you can find the details in [this comment](https://github.com/GEMINI-Medicine/Rgemini/issues/85#issuecomment-2113353757). Since `Hmisc` is a widely used package for EDA, in case others will encounter similar issue. 