### PR TITLE
129 use temptable and exists

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -43,7 +43,7 @@ Suggests:
     testthat (>= 3.0.0),
     viridis
 Config/testthat/edition: 3
-RoxygenNote: 7.3.1
+RoxygenNote: 7.3.2
 Roxygen: list(markdown = TRUE)
 VignetteBuilder: knitr
 Depends: 

--- a/R/readmission.R
+++ b/R/readmission.R
@@ -175,6 +175,12 @@ readmission <- function(dbcon,
   # Note: restricted cohort is the same in episodes_of_care & readmission function
   epicares <- episodes_of_care(dbcon = dbcon, restricted_cohort = restricted_cohort)
 
+  #load epicare as a temptable
+  DBI::dbSendQuery(dbcon,"Drop table if exists epicares_data;")
+  DBI::dbWriteTable(dbcon, c("pg_temp","epicares_data"), epicares[,.(genc_id)], row.names = F, overwrite = T)
+  #Analyze speed up the use of temp table
+  DBI::dbSendQuery(dbcon,"Analyze epicares_data")
+
   ############ Get additional DB variables ######################
   cat("Querying database ...\n")
 
@@ -188,20 +194,16 @@ readmission <- function(dbcon,
   admdad <- DBI::dbGetQuery(dbcon, paste0(
     "select genc_id, ", hospital_var, ", admission_date_time, discharge_date_time, admit_category, discharge_disposition
     from ", find_db_tablename(dbcon, "admdad", verbose = FALSE),
-    " where genc_id in (", paste(as.character(epicares$genc_id), sep = "' '", collapse = ","), ");"
+    " a where exists (select 1 from epicares_data t where t.genc_id=a.genc_id) ;"
   )) %>% as.data.table()
   data <- merge(admdad, epicares, by = "genc_id") %>% as.data.table()
-
-  ## write a temp table to improve querying efficiency
-  DBI::dbSendQuery(dbcon, "Drop table if exists temp_readmission_data;")
-  DBI::dbWriteTable(dbcon, c("pg_temp", "temp_readmission_data"), data[, .(genc_id)], row.names = FALSE, overwrite = TRUE)
 
   ## Ipdiagnosis data (if any relevant CIHI flag = TRUE)
   if (any(c(MAID, palliative, chemo, mental, obstetric))) {
     ipdiagnosis <- DBI::dbGetQuery(dbcon, paste0(
       "select genc_id, diagnosis_code, diagnosis_type
       from ", find_db_tablename(dbcon, "ipdiagnosis", verbose = FALSE),
-      " where genc_id in (select genc_id from temp_readmission_data);"
+      " i where exists (select 1 from epicares_data t where t.genc_id=i.genc_id);"
     )) %>% as.data.table()
   }
 
@@ -210,8 +212,8 @@ readmission <- function(dbcon,
     ipintervention <- DBI::dbGetQuery(dbcon, paste0(
       "select genc_id, intervention_code
       from ", find_db_tablename(dbcon, "ipintervention", verbose = FALSE),
-      " where intervention_code in ('1ZZ35HAP7','1ZZ35HAP1','1ZZ35HAN3') AND
-                                      genc_id in (select genc_id from temp_readmission_data);"
+      " i where intervention_code in ('1ZZ35HAP7','1ZZ35HAP1','1ZZ35HAN3') AND
+                                      exists (select 1 from epicares_data t where t.genc_id=i.genc_id);"
     )) %>% as.data.table()
   }
 
@@ -220,12 +222,9 @@ readmission <- function(dbcon,
     ipcmg <- DBI::dbGetQuery(dbcon, paste0(
       "select  genc_id, cmg
       from ", find_db_tablename(dbcon, "ipcmg", verbose = FALSE),
-      " WHERE genc_id in (select genc_id from temp_readmission_data)"
+      " i where exists (select 1 from epicares_data t where t.genc_id=i.genc_id)"
     )) %>% as.data.table()
   }
-
-  # Drop temp table after queries
-  DBI::dbSendQuery(dbcon, "Drop table if exists temp_readmission_data;")
 
   ############  Convert date-times into appropriate format   ############
   data[, discharge_date_time := convert_dt(discharge_date_time)]


### PR DESCRIPTION
I made a test script here to check the difference in output and speed of the where exists implementation and current implementation. 

I found there was no change in the output but there is indeed a speed difference. Generally with less number of hospitals the current pasting genc_ids seem to take less time to compute but more than 2-3 hospitals the where exists implementation is faster!

My test script here for reference:

##This script pushes the most updated rxnorm mapping into the sed_hyno_mapping file
library(Rgemini)
library(GEMINIpkg)
library(RPostgreSQL)
library(lubridate)
library(data.table)
library(getPass)
library(dplyr)
library(tictoc)
library(stringr)

source("~/git_hub/Rgemini/R/utils.R")

# Load DB con
drv <- dbDriver("PostgreSQL")
data.version <- "DB_version here"
db <- "db connection here"

adm<-dbGetQuery(db,"Select genc_id from admdad where hospital_id in ('hosp_1','hosp_2');")%>%data.table()

source("~/git_hub/Rgemini/R/episodes_of_care.R")
tic()
A<-evalq(episodes_of_care(db,restricted_cohort = adm), envir = .GlobalEnv)
toc()

tic()
B<-Rgemini::episodes_of_care(db,restricted_cohort = adm)
toc()
#Slightly slower with this implementation but it should scale up
#Confirm they are the same tables


#test readmission differences
source("~/git_hub/Rgemini/R/episodes_of_care.R")
tic()
A<-evalq(readmission(db,restricted_cohort = adm), envir = .GlobalEnv)
toc()
#29.139 seconds

tic()
B<-Rgemini::readmission(db,restricted_cohort = adm)
toc()
#31.707 seconds

delta<-anti_join(A,B)
#Joining with `by = join_by(genc_id, AT_in_occurred, AT_out_occurred, epicare, readmit7, readmit30)`
nrow(delta)
#No difference


#test loop_mlaps
adm_msh<-dbGetQuery(db,"Select genc_id from admdad where hospital_id in (''hosp_1);")%>%data.table()

source("~/git_hub/Rgemini/R/mlaps.R")
tic()
A<-evalq(loop_mlaps(db,cohort = adm_msh), envir = .GlobalEnv)
toc()
#297.682 sec elapsed

tic()
B<-Rgemini::loop_mlaps(db,cohort = adm_msh)
toc()
#116.039 sec elapsed

#test_diff
delta<-anti_join(A,B)
#Joining with `by = join_by(genc_id, mlaps)`
nrow(delta)
# [1] 0

#rest loop_maps with more genc_id
adm<-dbGetQuery(db,"Select genc_id from admdad where hospital_id in (''hosp_1','hosp_2',''hosp_3e');")%>%data.table()
source("~/git_hub/Rgemini/R/mlaps.R")
tic()
A<-evalq(loop_mlaps(db,cohort = adm), envir = .GlobalEnv)
toc()
#266.906 sec elapsed

tic()
B<-Rgemini::loop_mlaps(db,cohort = adm)
toc()
#832.176 sec elapsed

#test_diff
delta<-anti_join(A,B)
#Joining with `by = join_by(genc_id, mlaps)`
nrow(delta)
# [1] 0

