### PR TITLE
216 render strata fix

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # Rgemini `develop`
 
+* Fixed `render_cell_suppression.strat()` to be compatible with table1 version 1.5.0 
+
 * **Testing improvements:**
   * Unit tests are now also run in Python via rpy2 to ensure cross-language compatibility
 

--- a/R/cell_suppression.R
+++ b/R/cell_suppression.R
@@ -497,13 +497,16 @@ render_cell_suppression.continuous <- function(x, ...) {
 #' column in the call to [table1::table1()].
 #'
 #' @param label (`character`)\cr
-#' A character vector containing the labels.
-#'
-#' @param n (`numeric` or `character`)\cr
-#' A numeric vector containing the sizes.
+#' For table1 versions up to 1.4.3: A character vector containing the labels.
+#' For table1 versions >= 1.5.0: A list item with data for each strata.
 #'
 #' @param transpose (`logical`)\cr
 #' Used internally by [table1::table1()].
+#'
+#' @param ... \cr
+#' Optional additional arguments. Note that the current version expects this to
+#' be n for each strata, mimicing the behavior of table1 version <= 1.4.3, where
+#' n was explicitly passed to this function.
 #'
 #' @return named (`character`)\cr
 #' Concatenated with `""` to shift values down one row for proper alignment.
@@ -514,7 +517,19 @@ render_cell_suppression.continuous <- function(x, ...) {
 #'
 #' @export
 #'
-render_cell_suppression.strat <- function(label, n, transpose = FALSE) {
+render_cell_suppression.strat <- function(label, ..., transpose = FALSE) {
+
+  # Since table1 version 1.5.0:
+  # `label` is a list so we need to extract relevant info here
+  if (is.list(label)) {
+    n <- sapply(label, nrow)
+    label <- names(n)
+  } else {
+    # For previous table1 versions (<= 1.4.3): n was explicitly passed; here
+    # we check for implicit arguemnts to accommodate all versions of table1
+    n <- list(...)[[1]]
+  }
+
   sprintf(
     ifelse(
       is.na(n),
@@ -527,6 +542,7 @@ render_cell_suppression.strat <- function(label, n, transpose = FALSE) {
     ), label, n
   )
 }
+
 
 
 #' @title

--- a/tests/testthat/test-create_table1_gemini.R
+++ b/tests/testthat/test-create_table1_gemini.R
@@ -88,3 +88,22 @@ test_that("when a factor variable is missing levels, still can calculate SMD", {
     0.734
   )
 })
+
+test_that("strata render works without error (for table1 version 1.5.0 or newer)", {
+  set.seed(1)
+  continuous_data <- data.frame(
+    "age" = rnorm(100, mean = 70, sd = 10),
+    "laps" = abs(rnorm(100, mean = 1, sd = 1)),
+    "sex" = as.factor(c(rep("F", 30), rep("M", 70))),
+    "nobel" = sample(c("nobel prize won", "nobel prize not won"), 100, replace = TRUE, prob = c(0.01, 0.99))
+  )
+
+  expect_no_error(table1::table1(
+    ~ age + laps + sex | nobel,
+    data = continuous_data,
+    render.continuous = render_cell_suppression.continuous,
+    render.categorical = render_cell_suppression.categorical,
+    render.strat = render_cell_suppression.strat,
+    digits = 2
+  ))
+})


### PR DESCRIPTION
- fix for `render_cell_suppression.strat` to work with table1 version 1.5.0, as well as older versions (tested on 1.4.3)
- included unit test