### PR TITLE
#219 remove age exclusion

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,15 +1,7 @@
-# Rgemini `add GEMINIpkg::gemini_rxnorm_query()`
-
-* added GEMINIpkg::gemini_rxnorm_query() as rxnorm_query()
-* changed the db_con parameter to dbcon
-* removed the sites parameter
-* changed the genc_ids parameter to cohort
-* changed detailed_search and return_drug_list from being optional parameters to explicit parameters which default to NULL
-
-
 # Rgemini `develop`
 
-* Fixed `render_cell_suppression.strat()` to be compatible with table1 version 1.5.0 
+* Fixed `render_cell_suppression.strat()` to be compatible with table1 version 1.5.0
+* Removed age exclusion in `episodes_of_care()` to accommodate paeds cohort
 
 * **Testing improvements:**
   * Unit tests are now also run in Python via rpy2 to ensure cross-language compatibility

--- a/R/episodes_of_care.R
+++ b/R/episodes_of_care.R
@@ -60,7 +60,7 @@
 #' linked by transfers will have the same `epicare` number.
 #'
 #' @return (`data.frame`)\cr
-#' This function returns a `data.table` excluding records with invalid `patient_id_hashed`, `age < 18`, or
+#' This function returns a `data.table` excluding records with invalid `patient_id_hashed` or
 #' `admit_category` of cadaveric donors in line with CIHI guidelines.
 #' Nine columns are returned: `genc_id`, `patient_id_hashed`, `time_to_next_admission` (`numeric`),
 #' `time_since_last_admission` (`numeric`), `AT_in_coded` (`TRUE`/`FALSE`), `AT_out_coded` (`TRUE`/`FALSE`),
@@ -133,7 +133,7 @@ episodes_of_care <- function(dbcon, restricted_cohort = NULL) {
       DBI::dbSendQuery(dbcon, "Analyze temp_data")
 
       admdad <- DBI::dbGetQuery(dbcon, paste0(
-        "select genc_id, patient_id_hashed, age, admit_category, admission_date_time,
+        "select genc_id, patient_id_hashed, admit_category, admission_date_time,
                                             discharge_date_time
                                             from ", admdad_name,
         " a where exists (select 1 from temp_data t where t.genc_id=a.genc_id); "
@@ -141,7 +141,7 @@ episodes_of_care <- function(dbcon, restricted_cohort = NULL) {
     }
   } else {
     admdad <- DBI::dbGetQuery(dbcon, paste0(
-      "select genc_id, patient_id_hashed, age, admit_category, admission_date_time,
+      "select genc_id, patient_id_hashed, admit_category, admission_date_time,
                                             discharge_date_time
       from ", admdad_name
     )) %>% as.data.table()
@@ -152,9 +152,7 @@ episodes_of_care <- function(dbcon, restricted_cohort = NULL) {
 
   ############  Exclude invalid records   ############
   data <- data[!is.na(patient_id_hashed) & patient_id_hashed != ""] # remove invalid patient_id
-
   data <- data[!admit_category %in% c("R", "RI"), ] # cadaveric donors should not be in DB
-  data <- data[age >= 18, ] # age < 18 should not be in DB
 
   ############  Convert date-times into appropriate format   ############
   data[, discharge_date_time := convert_dt(discharge_date_time)]

--- a/man/episodes_of_care.Rd
+++ b/man/episodes_of_care.Rd
@@ -18,7 +18,7 @@ table in the user-provided database (recommended approach).}
 }
 \value{
 (\code{data.frame})\cr
-This function returns a \code{data.table} excluding records with invalid \code{patient_id_hashed}, \code{age < 18}, or
+This function returns a \code{data.table} excluding records with invalid \code{patient_id_hashed} or
 \code{admit_category} of cadaveric donors in line with CIHI guidelines.
 Nine columns are returned: \code{genc_id}, \code{patient_id_hashed}, \code{time_to_next_admission} (\code{numeric}),
 \code{time_since_last_admission} (\code{numeric}), \code{AT_in_coded} (\code{TRUE}/\code{FALSE}), \code{AT_out_coded} (\code{TRUE}/\code{FALSE}),


### PR DESCRIPTION
Closes #219 
The `age < 18` filter has been removed to make sure paeds encounters are included in `episodes_of_care` (also affecting readmission rates). This will be relevant for the release of the new DB version (drm_cleandb_v4) containing paeds data.