### PR TITLE
#276 update n rbc transfusions

### DIFF
--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -25,6 +25,7 @@ jobs:
     - name: Setup R
       uses: r-lib/actions/setup-r@v2
       with:
+          r-version: '4.5.1'
           use-public-rspm: true
 
     - name: Install dependencies

--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,7 @@
 * Updated `check_input()` and functions with `dbcon` input to accommodate `RPostgres`, `PostgreSQL`, and `odbc` connections
 * Changed DB input argument name in `loop_mlaps` from `db` to `dbcon`
 * Enhanced `find_db_tablename` to only search public schema
+* Updated `n_rbc_transfusions()` to include validated data from sites 105 & 106 in calculations.
 
 
 # Rgemini `2.0.0`

--- a/R/n_rbc_transfusions.R
+++ b/R/n_rbc_transfusions.R
@@ -89,7 +89,6 @@ n_rbc_transfusions <- function(dbcon,
 
 
   ## If relevant: Show warning notifying user of hospital exclusion
-  ## If relevant: Show warning notifying user of hospital exclusion
   if (any(c(105, 106) %in% unique(cohort$hospital_num))) {
     # Get discharge dates for hospitals 105/106 to determine exclusion
     genc_ids_105_106 <- cohort[hospital_num %in% c(105, 106), genc_id]

--- a/R/n_rbc_transfusions.R
+++ b/R/n_rbc_transfusions.R
@@ -47,10 +47,12 @@
 #' all RBC transfusions). Encounters without any transfusion will get a 0.
 #'
 #' @note
-#' Transfusion data from two hospitals with known data quality issues are
-#' automatically removed by this function. Any `genc_ids` from those sites are
-#' not included in the returned output. When merging the output of this function
-#' with another table, those `genc_ids` should have a value of `NA`.
+#' Transfusion data from two hospitals (105 and 106) with known historical
+#' data quality issues is automatically excluded for encounters with a
+#' `discharge_date_time` before 2021-01-01 00:00. Any `genc_ids` from those
+#' sites meeting this criterion are not included in the returned output.
+#' When merging the output of this function with another table, those
+#' `genc_ids` should have a value of `NA`.
 #'
 #' Currently, the function does not take `transfusion` or `lab` data coverage
 #' into account. For patients without RBC transfusion, the function will return
@@ -80,21 +82,44 @@ n_rbc_transfusions <- function(dbcon,
   check_input(exclude_ed, argtype = "logical")
   cohort <- coerce_to_datatable(cohort)
 
-  ## If relevant: Show warning notifying user of hospital exclusion
-  if (any(c(105, 106) %in% unique(cohort$hospital_num))) {
-    cat(paste0(
-      "Excluding hospitals with known transfusion data quality issues. ",
-      "Please refer to the function documentation for more details.\n",
-      nrow(cohort[hospital_num %in% c(105, 106)]), " genc_ids in the input cohort ",
-      "are from these hospitals, and they are excluded from the output table.\n\n"
-    ))
-  }
-  cohort_subset <- cohort[hospital_num %ni% c(105, 106)]
-
   # find table names for all relevant tables (admdad/lab/transfusion)
   admdad_table <- find_db_tablename(dbcon, "admdad", verbose = FALSE)
   lab_table <- find_db_tablename(dbcon, "lab", verbose = FALSE)
   transfusion_table <- find_db_tablename(dbcon, "transfusion", verbose = FALSE)
+
+
+  ## If relevant: Show warning notifying user of hospital exclusion
+  ## If relevant: Show warning notifying user of hospital exclusion
+  if (any(c(105, 106) %in% unique(cohort$hospital_num))) {
+    # Get discharge dates for hospitals 105/106 to determine exclusion
+    genc_ids_105_106 <- cohort[hospital_num %in% c(105, 106), genc_id]
+
+    discharge_dates <- dbGetQuery(
+      dbcon,
+      paste(
+        "select genc_id, discharge_date_time from", admdad_table,
+        "where genc_id in (", paste(genc_ids_105_106, collapse = ","), ")"
+      )
+    ) %>% as.data.table()
+
+    excluded_genc_ids <- discharge_dates[
+      convert_dt(discharge_date_time) < convert_dt("2021-01-01 00:00"),
+      genc_id
+    ]
+
+    if (length(excluded_genc_ids) > 0) {
+      cat(paste0(
+        "Excluding encounters from hospitals with known historical transfusion",
+        " data quality issues. ",
+        "Please refer to the function documentation for more details.\n",
+        length(excluded_genc_ids), " genc_ids in the input cohort ",
+        "are excluded from the output table.\n\n"
+      ))
+    }
+    cohort_subset <- cohort[!genc_id %in% excluded_genc_ids]
+  } else {
+    cohort_subset <- cohort
+  }
 
   # speed up query by using temp table with analyze
   temp_table(dbcon, cohort_subset[, .(genc_id)])

--- a/man/n_rbc_transfusions.Rd
+++ b/man/n_rbc_transfusions.Rd
@@ -58,10 +58,12 @@ prior to the transfusion are excluded. These scenarios are rare, typically
 occurring in approximately 2\% of blood transfusions in GEMINI data.
 }
 \note{
-Transfusion data from two hospitals with known data quality issues are
-automatically removed by this function. Any \code{genc_ids} from those sites are
-not included in the returned output. When merging the output of this function
-with another table, those \code{genc_ids} should have a value of \code{NA}.
+Transfusion data from two hospitals (105 and 106) with known historical
+data quality issues is automatically excluded for encounters with a
+\code{discharge_date_time} before 2021-01-01 00:00. Any \code{genc_ids} from those
+sites meeting this criterion are not included in the returned output.
+When merging the output of this function with another table, those
+\code{genc_ids} should have a value of \code{NA}.
 
 Currently, the function does not take \code{transfusion} or \code{lab} data coverage
 into account. For patients without RBC transfusion, the function will return


### PR DESCRIPTION
This pull request updates `n_rbc_transfusions` to include validated transfusion data from sites 105 & 106, rather than excluding the sites as a whole (#276). 

I tested the update on `drm_cleandb_v4_1_1` as well as `drm_cleandb_v3_1_0`. For both databases, the function worked as expected, giving NA values to 105/106 encounters who were discharged before 2021-01-01. The function gives valid numbers for encounters discharged on or after 2021-01-01.

To test the update on `drm_cleandb_v4_1_1`, I ran the following code:
```
## connect to drm cleandb
drv <- dbDriver("PostgreSQL")
db <- DBI::dbConnect(drv,
    dbname = "drm_cleandb_v4_1_1",
    host = "prime.smh.gemini-hpc.ca",
    port = 5432
)

### pull ALL 105/106 data
enc_105_106 <- dbGetQuery(db, "select genc_id, hospital_num, discharge_date_time from admdad where hospital_num in ('105', '106')") %>% data.table()

## load updated function
devtools::load_all("~/repos/Rgemini/")

## run function
rbc_test <- n_rbc_transfusions(dbcon = db, cohort = enc_105_106)

## merge results back with initial list of encounters
enc_105_106 <- enc_105_106 %>%
    merge(rbc_test, by = "genc_id", all.x = TRUE)

## filter for encounters discharged before 2021-01-01, ensure
## all derived rbc values are NA
enc_105_106[discharge_date_time < "2021-01-01 00:00" &
    (!is.na(n_rbc_transfusion_derived) | !is.na(n_app_rbc_transfusion_derived)) & hospital_num %in% c(105, 106)] ## no rows

# check for NA values in the valid period
enc_105_106[is.na(n_app_rbc_transfusion_derived) & discharge_date_time >= '2021-01-01 00:00'] ## no rows
```

The following query can be used to test on drm_cleandb versions < 4: 
```
enc_105_106 <- dbGetQuery(db, "select genc_id, hospital_id, discharge_date_time from admdad where hospital_id in (select hospital_id from lookup_hospital where hospital_num in ('105', '106'))") %>% data.table()
```
**Note:** hospital_num from `lookup_hospital` will need to be merged into the cohort table as it is not included in the admdad for earlier cleandb versions.