### PR TITLE
287 update mlaps function

### DIFF
--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -25,6 +25,7 @@ jobs:
     - name: Setup R
       uses: r-lib/actions/setup-r@v2
       with:
+            r-version: '4.5.1'
           use-public-rspm: true
 
     - name: Install dependencies

--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,7 @@
 * Updated `check_input()` and functions with `dbcon` input to accommodate `RPostgres`, `PostgreSQL`, and `odbc` connections
 * Changed DB input argument name in `loop_mlaps` from `db` to `dbcon`
 * Enhanced `find_db_tablename` to only search public schema
+* Updated `mlaps` calculation to exclude arterial blood gas point-of-care tests
 
 
 # Rgemini `2.0.0`

--- a/R/mlaps.R
+++ b/R/mlaps.R
@@ -194,6 +194,7 @@ loop_mlaps <- function(dbcon, cohort = NULL, hours_after_admission = 0, componen
           WHERE l.test_type_mapped_omop IN (", paste(LAPS_OMOP_CONCEPTS, collapse = ", "), ")",
           paste0("AND l.", hospital_field, " = '", hospital_id, "'"),
           "AND EXTRACT(YEAR FROM a.discharge_date_time::DATE) = ", year,
+          " AND NOT (test_type_mapped_omop in (3019977, 3027946, 3027801) and test_name_raw ~* 'POC|point of care')",
           if (!is.null(cohort)) {
             paste("and exists (select 1 from rgemini_temp_table c where c.genc_id=l.genc_id)")
           }
@@ -257,6 +258,7 @@ loop_mlaps <- function(dbcon, cohort = NULL, hours_after_admission = 0, componen
 #' For those encounters which were not returned, it may be reasonable to impute their LAPS score with zero
 #' if lab data was in principle available for their site and time period.
 #' If lab data was unavailable, it might be more accurate to assign the LAPS score for these encounters as `NA`.
+#' Arterial blood gas point-of-care tests are not used in mlaps calculation.
 #' In general it is recommended to take care and be intentional when imputing LAPS scores.
 #'
 #' @importFrom lubridate hours

--- a/R/mlaps.R
+++ b/R/mlaps.R
@@ -258,8 +258,8 @@ loop_mlaps <- function(dbcon, cohort = NULL, hours_after_admission = 0, componen
 #' For those encounters which were not returned, it may be reasonable to impute their LAPS score with zero
 #' if lab data was in principle available for their site and time period.
 #' If lab data was unavailable, it might be more accurate to assign the LAPS score for these encounters as `NA`.
-#' Arterial blood gas point-of-care tests are not used in mlaps calculation.
 #' In general it is recommended to take care and be intentional when imputing LAPS scores.
+#' Arterial blood gas point-of-care tests are not used in mlaps calculation.
 #'
 #' @importFrom lubridate hours
 #' @export

--- a/man/mlaps.Rd
+++ b/man/mlaps.Rd
@@ -51,8 +51,8 @@ Patients without entries in the lab table within \code{hours_of_admission} are n
 For those encounters which were not returned, it may be reasonable to impute their LAPS score with zero
 if lab data was in principle available for their site and time period.
 If lab data was unavailable, it might be more accurate to assign the LAPS score for these encounters as \code{NA}.
-Arterial blood gas point-of-care tests are not used in mlaps calculation.
 In general it is recommended to take care and be intentional when imputing LAPS scores.
+Arterial blood gas point-of-care tests are not used in mlaps calculation.
 }
 \references{
 When the function is used, please cite the following:

--- a/man/mlaps.Rd
+++ b/man/mlaps.Rd
@@ -51,6 +51,7 @@ Patients without entries in the lab table within \code{hours_of_admission} are n
 For those encounters which were not returned, it may be reasonable to impute their LAPS score with zero
 if lab data was in principle available for their site and time period.
 If lab data was unavailable, it might be more accurate to assign the LAPS score for these encounters as \code{NA}.
+Arterial blood gas point-of-care tests are not used in mlaps calculation.
 In general it is recommended to take care and be intentional when imputing LAPS scores.
 }
 \references{


### PR DESCRIPTION
This pull request updates `mlaps` to exclude arterial blood gas point-of-care tests. The exclusion is a regex string match performed during the initial SQL query that pulls lab tests based on `test_type_mapped_omop` codes for LAPS tests. 

To test the exclusion, I pulled a cohort of 1000 gencs that have arterial blood gas point-of-care lab tests performed. I compared the number of lab tests included before and after the exclusion. The result lab table was smaller after the exclusion was applied. For the site queried, mlaps score was not impacted because point-of-care tests seem to take place **_after_** admission. I compared mlaps after 24 hours and there was a difference before/after exclusion. (See photo below: res_included = POC tests included; res_excluded = POC tests excluded)
<img width="603" height="352" alt="image" src="https://github.com/user-attachments/assets/9535eac3-f7ea-42e4-9157-4ad72e4ea0de" />
