### PR TITLE
293 update neighbourhood ses

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -14,6 +14,7 @@
 * Updated `data_coverage()` to make `cohort` input optional
 * Minor fix to `plot_theme()` to ensure white plot background
 * Deprecated dummy functions that have been migrated to [`gemSim`](https://github.com/GEMINI-Medicine/gemSim)
+* Updated neighbourhood_ses to handle updated database versions
 
 
 # Rgemini `2.0.0`

--- a/NEWS.md
+++ b/NEWS.md
@@ -14,7 +14,7 @@
 * Updated `data_coverage()` to make `cohort` input optional
 * Minor fix to `plot_theme()` to ensure white plot background
 * Deprecated dummy functions that have been migrated to [`gemSim`](https://github.com/GEMINI-Medicine/gemSim)
-* Updated neighbourhood_ses to handle updated database versions
+* Updated `neighbourhood_ses()` to handle updated database versions
 
 
 # Rgemini `2.0.0`

--- a/R/neighbourhood_ses.R
+++ b/R/neighbourhood_ses.R
@@ -183,19 +183,41 @@ neighbourhood_ses <- function(dbcon, cohort, census_year) {
       }
     )
 
-    # query relevant columns
-    # note: columns with capital letters need "" to maintain column name
+    # detect column names: v4 uses uppercase, v5 uses lowercase
+    is_updated <- nrow(DBI::dbGetQuery(
+      dbcon, paste0(
+        "SELECT column_name FROM information_schema.columns ",
+        "WHERE table_name = '", statcan_table, "' ",
+        "AND column_name = 'age_labourforce_da21';"
+      )
+    )) > 0
+    # set up query for updated versions
+    changed_cols <- if (is_updated) {
+      paste0(
+        "s.age_labourforce_da21, s.age_labourforce_q_da21, ",
+        "s.households_dwellings_da21, s.households_dwellings_q_da21, ",
+        "s.material_resources_da21, s.material_resources_q_da21, ",
+        "s.racialized_nc_pop_da21, s.racialized_nc_pop_q_da21"
+      )
+    } else { # set up query for previous versions
+      paste0(
+        's."age_labourforce_DA21", s."age_labourforce_q_DA21", ',
+        's."households_dwellings_DA21", s."households_dwellings_q_DA21", ',
+        's."material_resources_DA21", s."material_resources_q_DA21", ',
+        's."racialized_NC_pop_DA21", s."racialized_NC_pop_q_DA21"'
+      )
+    }
+
+    ## query database using correct columm casing
     nbhd_data <- DBI::dbGetQuery(
       dbcon, paste(
-        "SELECT tmp.genc_id, l.da21uid, s.c21_vismin, s.c21_vismin_not, s.qnatippe, s.qnbtippe, s.qaatippe,
-      s.qabtippe, s.atippe, s.btippe, s.c21_immsta, s.c21_immsta_imm, s.c21_ed_15over_postsec,
-      s.c21_ed_15over, s.c21_ed_25to64_postsec, s.c21_ed_25to64, \"households_dwellings_DA21\",
-      \"material_resources_DA21\", \"age_labourforce_DA21\", \"racialized_NC_pop_DA21\",
-      \"households_dwellings_q_DA21\", \"material_resources_q_DA21\", \"age_labourforce_q_DA21\",
-      \"racialized_NC_pop_q_DA21\"
-      FROM rgemini_temp_table tmp
-      left join ", locality_table, " l on l.genc_id = tmp.genc_id
-      left join ", statcan_table, " s on l.da21uid = s.da21uid;"
+        "SELECT tmp.genc_id, l.da21uid, s.c21_vismin, s.c21_vismin_not, s.qnatippe,
+      s.qnbtippe, s.qaatippe, s.qabtippe, s.atippe, s.btippe, s.c21_immsta, s.c21_immsta_imm,
+      s.c21_ed_15over_postsec, s.c21_ed_15over, s.c21_ed_25to64_postsec, s.c21_ed_25to64, ",
+        changed_cols,
+        " FROM rgemini_temp_table tmp ",
+        "left join ", locality_table, " l on l.genc_id = tmp.genc_id ",
+        "left join ", statcan_table, " s on l.da21uid = s.da21uid;"
       )
     ) %>%
       as.data.table()

--- a/R/neighbourhood_ses.R
+++ b/R/neighbourhood_ses.R
@@ -183,7 +183,7 @@ neighbourhood_ses <- function(dbcon, cohort, census_year) {
       }
     )
 
-    # detect column names: v4 uses uppercase, v5 uses lowercase
+    # detect column casing: older has uppercase, newer uses lowercase
     is_updated <- nrow(DBI::dbGetQuery(
       dbcon, paste0(
         "SELECT column_name FROM information_schema.columns ",

--- a/R/neighbourhood_ses.R
+++ b/R/neighbourhood_ses.R
@@ -115,7 +115,7 @@
 #'  - Only including respondents between 25-64 years: `ed_25to64_postsec_pct`
 #' - Ontario Marginalization Index (continuous):
 #'  - If `census_year` = 2021: `households_dwellings`, `material_resources`,
-#' `age_labourforce`, `racialized_NC_pop`
+#' `age_labourforce`, `racialized_nc_pop`
 #'  - If `census_year` = 2016: `instability`, `deprivation`, `dependency`,
 #' `ethniccon`
 #' - Ontario Marginalization Index (quintiles):

--- a/man/neighbourhood_ses.Rd
+++ b/man/neighbourhood_ses.Rd
@@ -44,7 +44,7 @@ area, census agglomeration, or residual area within each province).
 \item Only including respondents between 25-64 years: \code{ed_25to64_postsec_pct}
 \item Ontario Marginalization Index (continuous):
 \item If \code{census_year} = 2021: \code{households_dwellings}, \code{material_resources},
-\code{age_labourforce}, \code{racialized_NC_pop}
+\code{age_labourforce}, \code{racialized_nc_pop}
 \item If \code{census_year} = 2016: \code{instability}, \code{deprivation}, \code{dependency},
 \code{ethniccon}
 \item Ontario Marginalization Index (quintiles):


### PR DESCRIPTION
This PR is for the updates made to `neighbourhood_ses()` (#293). The function now automatically handles upper- or lower-case column names in the `lookup_statcan_v2021` table.

I used the following code to test the update:
```
## connect to v4
drv <- dbDriver("PostgreSQL")
v4 <- DBI::dbConnect(drv,
    dbname = "drm_cleandb_v4_1_1",
    host = "prime.smh.gemini-hpc.ca",
    port = 5432
)

## connect to v5
v5 <- DBI::dbConnect(drv,
    dbname = "drm_cleandb_v5_0_0",
    host = "prime.smh.gemini-hpc.ca",
    port = 5432
)

## load package
devtools::load_all("~/repos/Rgemini/")

## pull a sample of genc_id (from v4 to ensure they **likely** exist in v5)
gencs <- dbGetQuery(v4, "select genc_id from admdad limit 1000")

## run for v4
v4_run <- neighbourhood_ses(v4, cohort = gencs, census_year = "2021")

## run for v5
v5_run <- neighbourhood_ses(v5, cohort = gencs, census_year = "2021")

### compare tables for equality - use clean_names due to column name diffs
all.equal(v4_run %>% janitor::clean_names(), v5_run %>% janitor::clean_names())

## compare column names for equality
compare_sets(tolower(names(v4_run)), names(v5_run))
```